### PR TITLE
install.sh: fix libssl.so.3 issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ msg "CPU architecture is OK."
 # pv:           for showing progress while downloading/extracting filesystems
 # pulseaudio:   for audio support
 lshout "Checking for required packages.."
-DEPENDS="git jq wget proot pv pulseaudio"
+DEPENDS="git jq wget proot pv pulseaudio openssl"
 TOINSTALL=""
 
 for DEPEND in $DEPENDS; do


### PR DESCRIPTION
fresh termux installation dosent come install with openssl (package which contains libssl.so.3) and wget requires libssl to communicate with https server to download anything.

adding openssl to dependencies resolves libssl.so.3 and wget works fine
fixes: (CANNOT LINK EXECUTABLE wget: library libssl.so.3 not found: needed by main executable) issue
manual fix: apt install -y openssl
manual fix only works with termux packages